### PR TITLE
Change symbol of the norm and add a radius to the Sphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 A Julia library to handle projections on manifolds. This is useful for minimizing functions or solving differential equations defined on manifolds.
 
-Currently, the sphere `{x ∈ K^n, |x| = 1}` and the Stiefel manifold `{X ∈ K^{n × m}, X'*X = I}` as well as independent copies of these manifolds are supported.
+Currently, the sphere `{x ∈ K^n, ||x|| = r}` and the Stiefel manifold `{X ∈ K^{n × m}, X'*X = I}` as well as independent copies of these manifolds are supported.
 
 Example usage:
 
@@ -8,7 +8,7 @@ Example usage:
 using ManifoldProjections
 
 x = randn(4)
-M = Sphere()
+M = Sphere() # create sphere with r = 1
 retract!(M,x)
 @assert norm(x) ≈ 1
 v = randn(4)

--- a/src/ManifoldProjections.jl
+++ b/src/ManifoldProjections.jl
@@ -21,7 +21,7 @@ end
 
 # fallback for out-of-place ops
 retract(M::Manifold, x) = retract!(M, copy(x))
-project_tangent(M::Manifold, g, x) = project_tangent!(M, copy(g), x)
+project_tangent(M::Manifold, g, x) = project_tangent!(M, copy(g), copy(x))
 
 # Fake objective function implementing a retraction
 mutable struct ManifoldObjective{T<:NLSolversBase.AbstractObjective} <: NLSolversBase.AbstractObjective
@@ -69,9 +69,17 @@ project_tangent!(M::Flat, g, x) = g
 """Spherical manifold {||x|| = r}."""
 struct Sphere{T} <: Manifold where {T <: Real}
     r::T
+    function Sphere(r)
+        if r == nothing
+            new{Nothing}(nothing)
+        elseif typeof(r) <: Real
+            r < 0 ? error("radius has to be a positive number!") : new{T}(r)
+        else
+            error("radius has to be a real number or nothing")
+        end
+    end
 end
 Sphere() = Sphere(nothing)
-# Sphere(r::T) where {T <: Real} = r < 0 ? error("radius has to be a positive number!") : Sphere{T}(r)
 retract!(S::Sphere{<:Nothing}, x) = normalize!(x)
 retract!(S::Sphere, x) = rmul!(x, S.r/norm(x))
 # TODO: is it the expected behavior to call retract! and change x here?

--- a/src/ManifoldProjections.jl
+++ b/src/ManifoldProjections.jl
@@ -66,11 +66,17 @@ retract!(M::Flat, x) = x
 project_tangent(M::Flat, g, x) = g
 project_tangent!(M::Flat, g, x) = g
 
-"""Spherical manifold {|x| = 1}."""
-struct Sphere <: Manifold
+"""Spherical manifold {||x|| = r}."""
+struct Sphere{T} <: Manifold where {T <: Real}
+    r::T
 end
-retract!(S::Sphere, x) = normalize!(x)
-project_tangent!(S::Sphere,g,x) = (g .-= real(dot(x,g)).*x)
+Sphere() = Sphere(nothing)
+# Sphere(r::T) where {T <: Real} = r < 0 ? error("radius has to be a positive number!") : Sphere{T}(r)
+retract!(S::Sphere{<:Nothing}, x) = normalize!(x)
+retract!(S::Sphere, x) = rmul!(x, S.r/norm(x))
+# TODO: is it the expected behavior to call retract! and change x here?
+project_tangent!(S::Sphere,g,x) = (retract!(S,x); g .-= (real(dot(x,g))/S.r^2).*x)
+project_tangent!(S::Sphere{<:Nothing},g,x) = (retract!(S,x); g .-= real(dot(x,g)).*x)
 
 """
 N x n matrices with orthonormal columns, i.e. such that X'X = I.

--- a/src/ManifoldProjections.jl
+++ b/src/ManifoldProjections.jl
@@ -69,7 +69,7 @@ project_tangent!(M::Flat, g, x) = g
 """Spherical manifold {||x|| = r}."""
 struct Sphere{T} <: Manifold where {T <: Real}
     r::T
-    Sphere(r) = r < 0 ? error("radius has to be a positive number!") : new{T}(r)
+    Sphere(r::T) where {T <: Real} = r < 0 ? error("radius has to be a positive number!") : new{T}(r)
 end
 Sphere() = Sphere(1)
 retract!(S::Sphere, x) = rmul!(x, S.r/norm(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,10 +9,8 @@ x = randn(4)+im*randn(4)
 M = Sphere()
 retract!(M,x)
 @test norm(x) ≈ 1
-x = randn(4)+im*randn(4)
 v = randn(4)+im*randn(4)
 @test project_tangent(M,v,x) == project_tangent!(M,v,x)
-@test norm(x) ≈ 1
 @test abs(real(v'*x)) < 1e-8
 ε = 1e-8
 @test (norm(x + ε*v) - 1) < ε^(3/2) # the tangent vector is such that x+εv is on the manifold up to O(ε^2)
@@ -23,10 +21,8 @@ x = randn(4)+im*randn(4)
 M = Sphere(r)
 retract!(M,x)
 @test norm(x) ≈ r
-x = randn(4)+im*randn(4)
 v = randn(4)+im*randn(4)
 @test project_tangent(M,v,x) == project_tangent!(M,v,x)
-@test norm(x) ≈ r
 @test abs(real(v'*x)) < 1e-8
 @test (norm(x + ε*v) - r) < ε^(3/2) # the tangent vector is such that x+εv is on the manifold up to O(ε^2)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,15 +4,31 @@ using LinearAlgebra
 using Random
 Random.seed!(0)
 
+# test sphere with radius 1
 x = randn(4)+im*randn(4)
 M = Sphere()
 retract!(M,x)
 @test norm(x) ≈ 1
+x = randn(4)+im*randn(4)
 v = randn(4)+im*randn(4)
 @test project_tangent(M,v,x) == project_tangent!(M,v,x)
+@test norm(x) ≈ 1
 @test abs(real(v'*x)) < 1e-8
 ε = 1e-8
 @test (norm(x + ε*v) - 1) < ε^(3/2) # the tangent vector is such that x+εv is on the manifold up to O(ε^2)
+
+# test sphere with radius r
+r = 120.0
+x = randn(4)+im*randn(4)
+M = Sphere(r)
+retract!(M,x)
+@test norm(x) ≈ r
+x = randn(4)+im*randn(4)
+v = randn(4)+im*randn(4)
+@test project_tangent(M,v,x) == project_tangent!(M,v,x)
+@test norm(x) ≈ r
+@test abs(real(v'*x)) < 1e-8
+@test (norm(x + ε*v) - r) < ε^(3/2) # the tangent vector is such that x+εv is on the manifold up to O(ε^2)
 
 for M in (Stiefel_CholQR(), Stiefel_SVD())
     X = randn(4,2) + im*randn(4,2)


### PR DESCRIPTION
A few comments:
As the old code would fail for project_tangent for x not on the surface corresponding to the sphere, I changed the code in a way that first projects x onto the surface and then does the projection.
If this is the way you think is appropriate, line 24 should be changed to 
`project_tangent(M::Manifold, g, x) = project_tangent!(M, copy(g), copy(x))`
else line 79 should be deleted and 78 changed to
`project_tangent!(S::Sphere,g,x) = (xnorm = normalize(x); g .-= (real(dot(xnorm,g))).*xnorm)`

If we want a Contructor that does some more checks we could use the following code
```
struct Sphere{T} <: Manifold where {T <: Real}
    r::T
    function Sphere(r)
        if r == nothing
            new{Nothing}(nothing)
        elseif typeof(r) <: Real
            r < 0 ? error("radius has to be a positive number!") : new{T}(r)
        else
            error("radius has to be a real number or nothing")
        end
    end
end

If you have any comments let me know
```

